### PR TITLE
Merge rtd3

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -30,6 +30,13 @@
                                'casesInfectionData':d3.csv('RtD3js/data/deaths/cases_by_infection.csv'),
                                'casesReportData':d3.csv('RtD3js/data/deaths/cases_by_report.csv'),
                                'obsCasesData':d3.csv('RtD3js/data/deaths/reported_cases.csv')}},
+          'data_ref':{
+            'summaryData':{'geometry_name':'Country'},
+            'rtData':{'geometry_name':'country'},
+            'casesInfectionData':{'geometry_name':'country'},
+            'casesReportData':{'geometry_name':'country'},
+            'obsCasesData':{'geometry_name':'region'},
+            'geoData':{'geometry_name':'sovereignt'}},
           'subregional_ref':{'Afghanistan':'https://epiforecasts.io/covid/posts/national/afghanistan/',
                              'Brazil':'https://epiforecasts.io/covid/posts/national/brazil/',
                              'Colombia':'https://epiforecasts.io/covid/posts/national/colombia/',

--- a/dist/index.html
+++ b/dist/index.html
@@ -39,8 +39,6 @@
                              'Russia':'https://epiforecasts.io/covid/posts/national/russia/',
                              'United Kingdom':'https://epiforecasts.io/covid/posts/national/united-kingdom/',
                              'United States of America':'https://epiforecasts.io/covid/posts/national/united-states/'},
-          'fullWidth':1200,
-          'downloadUrl':'https://github.com/epiforecasts/covid-rt-estimates/tree/master/national',
           'ts_color_ref':[{'value':90, type:'estimate', 'color':'#d1ebe3'},
                           {'value':90, type:'estimate based on partial data', 'color':'#f7dfcc'},
                           {'value':90, type:'forecast', 'color':'#e3e2ef'},

--- a/dist/index.html
+++ b/dist/index.html
@@ -12,6 +12,7 @@
         />
     </head>
     <body>
+        <div id="test" style="height:400px;"></div>
         <div id="root"></div>
         <script>
         // Need a function to render the app in the root element (any root element). Should be easy with import App from module

--- a/dist/index.html
+++ b/dist/index.html
@@ -12,7 +12,6 @@
         />
     </head>
     <body>
-        <div id="test" style="height:400px;"></div>
         <div id="root"></div>
         <script>
         // Need a function to render the app in the root element (any root element). Should be easy with import App from module

--- a/dist/index.html
+++ b/dist/index.html
@@ -1,13 +1,14 @@
 <html>
     <head>
         <title>RtD3js</title>
-        <script src="RtD3js/react.js"></script>
-        <script src="RtD3js/react-dom.js"></script>
-        <script src="RtD3js/d3.v6.min.js"></script>
+        <script src="https://unpkg.com/react@15/dist/react.js"></script>
+        <script src="https://unpkg.com/react-dom@15/dist/react-dom.js"></script>
+        <script src="https://d3js.org/d3.v6.min.js"></script>
         <script type="text/javascript" src="main.js"></script>
         <link
           rel="stylesheet"
-          href="RtD3js/bootstrap.min.css"
+          href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css"
+          integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk"
           crossorigin="anonymous"
         />
     </head>
@@ -19,17 +20,17 @@
         var x = {
           'activeArea':'United Kingdom',
           'activeTime':'all',
-          'geoData':d3.json('RtD3js/data/world2.geojson'),
-          'rtData': {'Cases':{'summaryData':d3.csv('RtD3js/data/cases/summary_table.csv'),
-                              'rtData':d3.csv('RtD3js/data/cases/rt.csv'),
-                              'casesInfectionData':d3.csv('RtD3js/data/cases/cases_by_infection.csv'),
-                              'casesReportData':d3.csv('RtD3js/data/cases/cases_by_report.csv'),
-                              'obsCasesData':d3.csv('RtD3js/data/cases/reported_cases.csv')},
-                     'Deaths':{'summaryData':d3.csv('RtD3js/data/deaths/summary_table.csv'),
-                               'rtData':d3.csv('RtD3js/data/deaths/rt.csv'),
-                               'casesInfectionData':d3.csv('RtD3js/data/deaths/cases_by_infection.csv'),
-                               'casesReportData':d3.csv('RtD3js/data/deaths/cases_by_report.csv'),
-                               'obsCasesData':d3.csv('RtD3js/data/deaths/reported_cases.csv')}},
+          'geoData':d3.json('https://raw.githubusercontent.com/hamishgibbs/rt_interactive_vis/master/geo_data/world2.geojson'),
+          'rtData': {'Cases':{'summaryData':d3.csv('https://raw.githubusercontent.com/epiforecasts/covid-rt-estimates/master/national/cases/summary/summary_table.csv'),
+                              'rtData':d3.csv('https://raw.githubusercontent.com/epiforecasts/covid-rt-estimates/master/national/cases/summary/rt.csv'),
+                              'casesInfectionData':d3.csv('https://raw.githubusercontent.com/epiforecasts/covid-rt-estimates/master/national/cases/summary/cases_by_infection.csv'),
+                              'casesReportData':d3.csv('https://raw.githubusercontent.com/epiforecasts/covid-rt-estimates/master/national/cases/summary/cases_by_report.csv'),
+                              'obsCasesData':d3.csv('https://raw.githubusercontent.com/epiforecasts/covid-rt-estimates/master/national/cases/summary/reported_cases.csv')},
+                     'Deaths':{'summaryData':d3.csv('https://raw.githubusercontent.com/epiforecasts/covid-rt-estimates/master/national/deaths/summary/summary_table.csv'),
+                               'rtData':d3.csv('https://raw.githubusercontent.com/epiforecasts/covid-rt-estimates/master/national/deaths/summary/rt.csv'),
+                               'casesInfectionData':d3.csv('https://raw.githubusercontent.com/epiforecasts/covid-rt-estimates/master/national/deaths/summary/cases_by_infection.csv'),
+                               'casesReportData':d3.csv('https://raw.githubusercontent.com/epiforecasts/covid-rt-estimates/master/national/deaths/summary/cases_by_report.csv'),
+                               'obsCasesData':d3.csv('https://raw.githubusercontent.com/epiforecasts/covid-rt-estimates/master/national/deaths/summary/reported_cases.csv')}},
           'data_ref':{
             'summaryData':{'geometry_name':'Country'},
             'rtData':{'geometry_name':'country'},

--- a/dist/main.js
+++ b/dist/main.js
@@ -206,7 +206,7 @@ var TimeseriesPlot = /*#__PURE__*/function (_React$Component) {
       d3.select("#" + this.props.container_id).append("div").style("opacity", 0).attr("class", 'tooltip').attr('id', this.props.container_id + '-tooltip').style('position', 'absolute').style('background-color', 'white').style('border', '1px solid black').style('border-radius', '15px').style('padding', '5px');
       svg.append('line').attr('id', this.props.container_id + '-hover-line').attr("x1", 20).attr("y1", 0).attr("x2", 20).attr("y2", svg_dims.height).attr('stroke', 'black').attr('stroke-width', '1px').attr('stroke-opacity', 0);
       svg.append("rect").attr("width", svg_dims.width).attr("height", svg_dims.height).style("fill", "none").style("pointer-events", "all").attr('transform', 'translate(' + this.margin.left + ',' + this.margin.top + ')').call(zoom).on('mousemove', function (e) {
-        var hovered_x = _this3.active_x.invert(e.clientX);
+        var hovered_x = _this3.active_x.invert(e.pageX);
 
         var hovered_x_formatted = hovered_x.toISOString().slice(0, 10);
 
@@ -218,8 +218,8 @@ var TimeseriesPlot = /*#__PURE__*/function (_React$Component) {
 
         var tooltip_string = _this3.format_tooltip_string(hover_data, cis, _this3.props.data_ref['rtData']['geometry_name']);
 
-        d3.select('#' + _this3.props.container_id + '-tooltip').style("left", e.clientX + 40 + "px").style("top", e.clientY + _this3.props.map_height - 200 + "px").html(tooltip_string);
-        d3.select('#' + _this3.props.container_id + '-hover-line').attr('x1', e.clientX - 60).attr('x2', e.clientX - 60);
+        d3.select('#' + _this3.props.container_id + '-tooltip').style("left", e.pageX + 40 + "px").style("top", e.pageY + "px").html(tooltip_string);
+        d3.select('#' + _this3.props.container_id + '-hover-line').attr('x1', e.pageX - 60).attr('x2', e.pageX - 60);
       }).on('mouseenter', function (e) {
         d3.select('#' + _this3.props.container_id + '-tooltip').style("opacity", 1);
         d3.select('#' + _this3.props.container_id + '-hover-line').attr('stroke-opacity', 1);
@@ -455,8 +455,6 @@ var Map = /*#__PURE__*/function (_React$Component) {
         function format_tooltip_string(hovered_data, legend_ref) {
           return '<b>' + hovered_data[summaryData_geometry_name] + '</b></br><b>' + legend_ref['variable_name'] + ': </b>' + hovered_data[legend_ref['variable_name']];
         }
-
-        console.log(e);
 
         try {
           Map_d3.select('#' + container_id + '-tooltip').style("left", e.pageX + 40 + "px").style("top", e.pageY + "px").html(format_tooltip_string(hovered_data, legend_ref));

--- a/dist/main.js
+++ b/dist/main.js
@@ -422,6 +422,7 @@ var Map = /*#__PURE__*/function (_React$Component) {
 
       Map_d3.selectAll('#' + this.props.content_id).remove();
       var svg_dims = document.getElementById(this.props.container_id).getBoundingClientRect();
+      var summaryData_geometry_name = this.props.data_ref['summaryData']['geometry_name'];
       var projection = Map_d3[this.props.projection]().fitSize([svg_dims.width, svg_dims.height], this.props.geoData);
       var path = Map_d3.geoPath().projection(projection);
       var svg = Map_d3.select('#' + this.props.svg_id).append('g').attr('id', this.props.content_id).attr("transform", "translate(" + this.margin.left + "," + this.margin.top + ")");
@@ -436,23 +437,23 @@ var Map = /*#__PURE__*/function (_React$Component) {
       var container_id = this.props.container_id;
       var legend_ref = this.props.legend_ref;
       g.selectAll("path").data(this.props.geoData.features).enter().append("path").attr("d", path).attr('region-name', function (feature) {
-        return feature.properties.sovereignt;
+        return feature.properties[_this2.props.data_ref['geoData']['geometry_name']];
       }).attr('fill', function (feature) {
-        var feature_name = feature.properties.sovereignt;
+        var feature_name = feature.properties[_this2.props.data_ref['geoData']['geometry_name']];
 
         if (_this2.props.legend_ref['legend_type'] === 'qualitative') {
-          return _this2.qualitative_fill(feature_name, _this2.props.summaryData, _this2.props.legend_ref);
+          return _this2.qualitative_fill(feature_name, _this2.props.summaryData, summaryData_geometry_name, _this2.props.legend_ref);
         } else if (_this2.props.legend_ref['legend_type'] === 'sequential') {
-          return _this2.sequential_fill(feature_name, _this2.props.summaryData, scale_sequential, _this2.props.legend_ref);
+          return _this2.sequential_fill(feature_name, _this2.props.summaryData, summaryData_geometry_name, scale_sequential, _this2.props.legend_ref);
         }
       }).attr('stroke', '#333').on('mousemove', function (e) {
         var hovered_name = Map_d3.select(this).attr('region-name');
         var hovered_data = data.filter(function (d) {
-          return d.region == hovered_name;
+          return d[summaryData_geometry_name] == hovered_name;
         })[0];
 
         function format_tooltip_string(hovered_data, legend_ref) {
-          return '<b>' + hovered_data['region'] + '</b></br><b>' + legend_ref['variable_name'] + ': </b>' + hovered_data[legend_ref['variable_name']];
+          return '<b>' + hovered_data[summaryData_geometry_name] + '</b></br><b>' + legend_ref['variable_name'] + ': </b>' + hovered_data[legend_ref['variable_name']];
         }
 
         try {
@@ -475,9 +476,9 @@ var Map = /*#__PURE__*/function (_React$Component) {
     }
   }, {
     key: "sequential_fill",
-    value: function sequential_fill(feature_name, summaryData, legend_scale, legend_ref) {
+    value: function sequential_fill(feature_name, summaryData, geometry_name, legend_scale, legend_ref) {
       var summary_data = summaryData.filter(function (d) {
-        if (d.region == feature_name) {
+        if (d[geometry_name] == feature_name) {
           return d;
         }
       });
@@ -491,9 +492,9 @@ var Map = /*#__PURE__*/function (_React$Component) {
     }
   }, {
     key: "qualitative_fill",
-    value: function qualitative_fill(feature_name, summaryData, legend_ref) {
+    value: function qualitative_fill(feature_name, summaryData, geometry_name, legend_ref) {
       var summary_data = summaryData.filter(function (d) {
-        if (d.region == feature_name) {
+        if (d[geometry_name] == feature_name) {
           return d;
         }
       });

--- a/dist/main.js
+++ b/dist/main.js
@@ -757,9 +757,11 @@ var CountrySelect = /*#__PURE__*/function (_React$Component) {
   CountrySelect_createClass(CountrySelect, [{
     key: "render",
     value: function render() {
+      var _this = this;
+
       var region_options = [];
       this.props.summaryData.map(function (item) {
-        region_options.push( /*#__PURE__*/CountrySelect_React.createElement("option", null, item['Country']));
+        region_options.push( /*#__PURE__*/CountrySelect_React.createElement("option", null, item[_this.props.data_ref['summaryData']['geometry_name']]));
       });
       var source_options = [];
       this.props.data_sources.map(function (item) {
@@ -1110,7 +1112,8 @@ var SummaryWidget = /*#__PURE__*/function (_React$Component) {
           data_sources: Object.keys(this.state.rtData),
           active_area: this.state.active_area,
           select_handler: this.update_region_state.bind(this),
-          source_select_handler: this.update_source_state.bind(this)
+          source_select_handler: this.update_source_state.bind(this),
+          data_ref: this.props.x.data_ref
         }), /*#__PURE__*/summaryWidget_React.createElement(TimeseriesPlot, {
           container_id: "r-container",
           svg_id: "r-svg",

--- a/dist/main.js
+++ b/dist/main.js
@@ -147,9 +147,10 @@ var TimeseriesPlot = /*#__PURE__*/function (_React$Component) {
 
       var cis = this.getCIs(this.props.data); // Get the value of the highest CI
 
-      var max_ci = d3.max(cis.map(function (ci) {
+      var cis_numeric = cis.map(function (ci) {
         return ci['value'];
-      })); // Y max is the max of the highest CI
+      });
+      var max_ci = d3.max(cis_numeric); // Y max is the max of the highest CI
 
       var y_max = d3.max(this.props.data.map(function (d) {
         return parseFloat(d['upper_' + max_ci]);
@@ -971,8 +972,8 @@ var SummaryWidget = /*#__PURE__*/function (_React$Component) {
 
 
               if (['rtData', 'casesInfectionData', 'casesReportData'].includes(sub_key)) {
-                var min_date = summaryWidget_d3.min(_this2.get_dates(_this2.filterData(_this2.state.active_area, data)));
-                var max_date = summaryWidget_d3.max(_this2.get_dates(_this2.filterData(_this2.state.active_area, data)));
+                var min_date = summaryWidget_d3.min(_this2.get_dates(_this2.filterData(_this2.state.active_area, data, _this2.props.x.data_ref[sub_key]['geometry_name'])));
+                var max_date = summaryWidget_d3.max(_this2.get_dates(_this2.filterData(_this2.state.active_area, data, _this2.props.x.data_ref[sub_key]['geometry_name'])));
 
                 _this2.setState({
                   min_date: min_date,
@@ -1041,23 +1042,11 @@ var SummaryWidget = /*#__PURE__*/function (_React$Component) {
     }
   }, {
     key: "filterData",
-    value: function filterData(region, input) {
-      var filter_var = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 'region';
+    value: function filterData(region, input, geometry_name) {
+      var filter_var = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : 'region';
       // Filters an array for an arbitrary value by an arbitrary column
-      var input_keys = Object.keys(input[0]); // Add flexibility for the most common filtered variables. Assumes there is only one of these per dataset
-
-      if (input_keys.includes('region')) {
-        filter_var = 'region';
-      } else if (input_keys.includes('country')) {
-        filter_var = 'country';
-      } else if (input_keys.includes('Country')) {
-        filter_var = 'Country';
-      } else if (input_keys.includes('Region')) {
-        filter_var = 'Region';
-      }
-
       var filtered = input.filter(function (e) {
-        return e[filter_var] == region;
+        return e[geometry_name] == region;
       });
       return filtered;
     }
@@ -1083,12 +1072,12 @@ var SummaryWidget = /*#__PURE__*/function (_React$Component) {
           className: "text-muted"
         }, "Loading..."));
       } else {
-        var activeRtData = this.filterData(this.state.active_area, this.state.rtData[this.state.active_source]['rtData']);
-        var activeCasesInfectionData = this.filterData(this.state.active_area, this.state.rtData[this.state.active_source]['casesInfectionData']);
-        var activeCasesReportData = this.filterData(this.state.active_area, this.state.rtData[this.state.active_source]['casesReportData']);
-        var activeObsCasesData = this.filterData(this.state.active_area, this.state.rtData[this.state.active_source]['obsCasesData']);
-        console.log(this.state.rtData[this.state.active_source]['summaryData']);
-        console.log(this.props.x);
+        var activeRtData = this.filterData(this.state.active_area, this.state.rtData[this.state.active_source]['rtData'], this.props.x.data_ref['rtData']['geometry_name']);
+        var activeCasesInfectionData = this.filterData(this.state.active_area, this.state.rtData[this.state.active_source]['casesInfectionData'], this.props.x.data_ref['casesInfectionData']['geometry_name']);
+        var activeCasesReportData = this.filterData(this.state.active_area, this.state.rtData[this.state.active_source]['casesReportData'], this.props.x.data_ref['casesReportData']['geometry_name']);
+        var activeObsCasesData = this.filterData(this.state.active_area, this.state.rtData[this.state.active_source]['obsCasesData'], this.props.x.data_ref['obsCasesData']['geometry_name']);
+        console.log(this.props.x.data_ref['rtData']['geometry_name']);
+        console.log(activeRtData);
         var plot_height = '200px';
         var map_height = 600;
         return /*#__PURE__*/summaryWidget_React.createElement("div", null, /*#__PURE__*/summaryWidget_React.createElement(Map, {

--- a/dist/main.js
+++ b/dist/main.js
@@ -456,8 +456,10 @@ var Map = /*#__PURE__*/function (_React$Component) {
           return '<b>' + hovered_data[summaryData_geometry_name] + '</b></br><b>' + legend_ref['variable_name'] + ': </b>' + hovered_data[legend_ref['variable_name']];
         }
 
+        console.log(e);
+
         try {
-          Map_d3.select('#' + container_id + '-tooltip').style("left", e.clientX + 40 + "px").style("top", e.clientY + "px").html(format_tooltip_string(hovered_data, legend_ref));
+          Map_d3.select('#' + container_id + '-tooltip').style("left", e.pageX + 40 + "px").style("top", e.pageY + "px").html(format_tooltip_string(hovered_data, legend_ref));
         } catch (_unused) {
           Map_d3.select('#' + container_id + '-tooltip').style("opacity", 0);
         }

--- a/dist/main.js
+++ b/dist/main.js
@@ -940,35 +940,53 @@ var SummaryWidget = /*#__PURE__*/function (_React$Component) {
       // Default to the first map legend
       this.setState({
         active_map_legend: this.props.x.map_legend_ref[0]
-      });
-      this.props.x.geoData.then(function (data) {
-        _this2.setState({
-          geoData: data
+      }); // Try to resolve promise or accept array
+
+      try {
+        this.props.x.geoData.then(function (data) {
+          _this2.setState({
+            geoData: data
+          });
         });
-      }); //rtData is nested recursively
+      } catch (_unused) {
+        this.setState({
+          geoData: this.props.x.geoData
+        });
+      }
+
+      try {} catch (_unused2) {} //rtData is nested recursively
+
 
       Object.keys(this.props.x.rtData).map(function (key, index) {
         _this2.state.rtData[key] = new Object();
         Object.keys(_this2.props.x.rtData[key]).map(function (sub_key, sub_index) {
-          _this2.props.x.rtData[key][sub_key].then(function (data) {
-            // setState needs to be called for nested state
+          try {
+            _this2.props.x.rtData[key][sub_key].then(function (data) {
+              // setState needs to be called for nested state
+              _this2.setState(function (prevState) {
+                return {
+                  rtData: _objectSpread(_objectSpread({}, prevState.rtData), {}, summaryWidget_defineProperty({}, key, _objectSpread(_objectSpread({}, prevState.rtData[key]), {}, summaryWidget_defineProperty({}, sub_key, data))))
+                };
+              }); // Also setting the min and max dates of the active area here
+
+
+              if (['rtData', 'casesInfectionData', 'casesReportData'].includes(sub_key)) {
+                var min_date = summaryWidget_d3.min(_this2.get_dates(_this2.filterData(_this2.state.active_area, data)));
+                var max_date = summaryWidget_d3.max(_this2.get_dates(_this2.filterData(_this2.state.active_area, data)));
+
+                _this2.setState({
+                  min_date: min_date,
+                  max_date: max_date
+                });
+              }
+            });
+          } catch (_unused3) {
             _this2.setState(function (prevState) {
               return {
-                rtData: _objectSpread(_objectSpread({}, prevState.rtData), {}, summaryWidget_defineProperty({}, key, _objectSpread(_objectSpread({}, prevState.rtData[key]), {}, summaryWidget_defineProperty({}, sub_key, data))))
+                rtData: _objectSpread(_objectSpread({}, prevState.rtData), {}, summaryWidget_defineProperty({}, key, _objectSpread(_objectSpread({}, prevState.rtData[key]), {}, summaryWidget_defineProperty({}, sub_key, _this2.props.x.rtData[key][sub_key]))))
               };
-            }); // Also setting the min and max dates of the active area here
-
-
-            if (['rtData', 'casesInfectionData', 'casesReportData'].includes(sub_key)) {
-              var min_date = summaryWidget_d3.min(_this2.get_dates(_this2.filterData(_this2.state.active_area, data)));
-              var max_date = summaryWidget_d3.max(_this2.get_dates(_this2.filterData(_this2.state.active_area, data)));
-
-              _this2.setState({
-                min_date: min_date,
-                max_date: max_date
-              });
-            }
-          });
+            });
+          }
         });
       });
     }
@@ -1119,7 +1137,8 @@ var SummaryWidget = /*#__PURE__*/function (_React$Component) {
           data: activeCasesInfectionData,
           map_height: map_height,
           obsCasesData: activeObsCasesData,
-          ts_bar_color: this.props.x.ts_bar_color
+          ts_bar_color: this.props.x.ts_bar_color,
+          credible_threshold: this.props.x.credible_threshold
         }), /*#__PURE__*/summaryWidget_React.createElement(TimeseriesPlot, {
           container_id: "report-container",
           svg_id: "report-svg",
@@ -1134,7 +1153,8 @@ var SummaryWidget = /*#__PURE__*/function (_React$Component) {
           data: activeCasesReportData,
           map_height: map_height,
           obsCasesData: activeObsCasesData,
-          ts_bar_color: this.props.x.ts_bar_color
+          ts_bar_color: this.props.x.ts_bar_color,
+          credible_threshold: this.props.x.credible_threshold
         }), /*#__PURE__*/summaryWidget_React.createElement(TimeseriesLegend, {
           ts_color_ref: this.props.x.ts_color_ref
         }));

--- a/dist/main.js
+++ b/dist/main.js
@@ -216,7 +216,7 @@ var TimeseriesPlot = /*#__PURE__*/function (_React$Component) {
           }
         })[0];
 
-        var tooltip_string = _this3.format_tooltip_string(hover_data, cis);
+        var tooltip_string = _this3.format_tooltip_string(hover_data, cis, _this3.props.data_ref['rtData']['geometry_name']);
 
         d3.select('#' + _this3.props.container_id + '-tooltip').style("left", e.clientX + 40 + "px").style("top", e.clientY + _this3.props.map_height - 200 + "px").html(tooltip_string);
         d3.select('#' + _this3.props.container_id + '-hover-line').attr('x1', e.clientX - 60).attr('x2', e.clientX - 60);
@@ -274,9 +274,9 @@ var TimeseriesPlot = /*#__PURE__*/function (_React$Component) {
     }
   }, {
     key: "format_tooltip_string",
-    value: function format_tooltip_string(hover_data, cis) {
+    value: function format_tooltip_string(hover_data, cis, geometry_name) {
       var sep = '</br>';
-      var hover_str = '<b>' + hover_data['country'] + '</b>' + sep + '<b>' + hover_data['date'] + '</b>';
+      var hover_str = '<b>' + hover_data[geometry_name] + '</b>' + sep + '<b>' + hover_data['date'] + '</b>';
       hover_str = hover_str + cis.map(function (ci) {
         return sep + '<b>' + ci['value'] + '% CI: </b>' + hover_data[ci['lower_name']] + ' - ' + hover_data[ci['upper_name']];
       });
@@ -1076,8 +1076,6 @@ var SummaryWidget = /*#__PURE__*/function (_React$Component) {
         var activeCasesInfectionData = this.filterData(this.state.active_area, this.state.rtData[this.state.active_source]['casesInfectionData'], this.props.x.data_ref['casesInfectionData']['geometry_name']);
         var activeCasesReportData = this.filterData(this.state.active_area, this.state.rtData[this.state.active_source]['casesReportData'], this.props.x.data_ref['casesReportData']['geometry_name']);
         var activeObsCasesData = this.filterData(this.state.active_area, this.state.rtData[this.state.active_source]['obsCasesData'], this.props.x.data_ref['obsCasesData']['geometry_name']);
-        console.log(this.props.x.data_ref['rtData']['geometry_name']);
-        console.log(activeRtData);
         var plot_height = '200px';
         var map_height = 600;
         return /*#__PURE__*/summaryWidget_React.createElement("div", null, /*#__PURE__*/summaryWidget_React.createElement(Map, {
@@ -1088,6 +1086,7 @@ var SummaryWidget = /*#__PURE__*/function (_React$Component) {
           height: map_height + 'px',
           geoData: this.state.geoData,
           summaryData: this.state.rtData[this.state.active_source]['summaryData'],
+          data_ref: this.props.x.data_ref,
           projection: this.props.x.projection,
           legend_ref: this.state.active_map_legend,
           create_sequential_legend: this.create_sequential_legend,
@@ -1122,6 +1121,7 @@ var SummaryWidget = /*#__PURE__*/function (_React$Component) {
           min_date: this.state.min_date,
           max_date: this.state.max_date,
           ts_color_ref: this.props.x.ts_color_ref,
+          data_ref: this.props.x.data_ref,
           data: activeRtData,
           map_height: map_height,
           hline_intercept: 1
@@ -1136,6 +1136,7 @@ var SummaryWidget = /*#__PURE__*/function (_React$Component) {
           min_date: this.state.min_date,
           max_date: this.state.max_date,
           ts_color_ref: this.props.x.ts_color_ref,
+          data_ref: this.props.x.data_ref,
           data: activeCasesInfectionData,
           map_height: map_height,
           obsCasesData: activeObsCasesData,
@@ -1152,6 +1153,7 @@ var SummaryWidget = /*#__PURE__*/function (_React$Component) {
           min_date: this.state.min_date,
           max_date: this.state.max_date,
           ts_color_ref: this.props.x.ts_color_ref,
+          data_ref: this.props.x.data_ref,
           data: activeCasesReportData,
           map_height: map_height,
           obsCasesData: activeObsCasesData,

--- a/dist/main.js
+++ b/dist/main.js
@@ -447,11 +447,11 @@ var Map = /*#__PURE__*/function (_React$Component) {
       }).attr('stroke', '#333').on('mousemove', function (e) {
         var hovered_name = Map_d3.select(this).attr('region-name');
         var hovered_data = data.filter(function (d) {
-          return d.Country == hovered_name;
+          return d.region == hovered_name;
         })[0];
 
         function format_tooltip_string(hovered_data, legend_ref) {
-          return '<b>' + hovered_data['Country'] + '</b></br><b>' + legend_ref['variable_name'] + ': </b>' + hovered_data[legend_ref['variable_name']];
+          return '<b>' + hovered_data['region'] + '</b></br><b>' + legend_ref['variable_name'] + ': </b>' + hovered_data[legend_ref['variable_name']];
         }
 
         try {
@@ -476,7 +476,7 @@ var Map = /*#__PURE__*/function (_React$Component) {
     key: "sequential_fill",
     value: function sequential_fill(feature_name, summaryData, legend_scale, legend_ref) {
       var summary_data = summaryData.filter(function (d) {
-        if (d.Country == feature_name) {
+        if (d.region == feature_name) {
           return d;
         }
       });
@@ -492,7 +492,7 @@ var Map = /*#__PURE__*/function (_React$Component) {
     key: "qualitative_fill",
     value: function qualitative_fill(feature_name, summaryData, legend_ref) {
       var summary_data = summaryData.filter(function (d) {
-        if (d.Country == feature_name) {
+        if (d.region == feature_name) {
           return d;
         }
       });
@@ -1076,8 +1076,6 @@ var SummaryWidget = /*#__PURE__*/function (_React$Component) {
   }, {
     key: "render",
     value: function render() {
-      console.log(this.state);
-
       if (Object.keys(this.state.rtData[this.state.active_source]).length <= 3) {
         return /*#__PURE__*/summaryWidget_React.createElement("div", {
           className: "d-flex justify-content-center pt-4"
@@ -1089,6 +1087,8 @@ var SummaryWidget = /*#__PURE__*/function (_React$Component) {
         var activeCasesInfectionData = this.filterData(this.state.active_area, this.state.rtData[this.state.active_source]['casesInfectionData']);
         var activeCasesReportData = this.filterData(this.state.active_area, this.state.rtData[this.state.active_source]['casesReportData']);
         var activeObsCasesData = this.filterData(this.state.active_area, this.state.rtData[this.state.active_source]['obsCasesData']);
+        console.log(this.state.rtData[this.state.active_source]['summaryData']);
+        console.log(this.props.x);
         var plot_height = '200px';
         var map_height = 600;
         return /*#__PURE__*/summaryWidget_React.createElement("div", null, /*#__PURE__*/summaryWidget_React.createElement(Map, {

--- a/dist/main.js
+++ b/dist/main.js
@@ -985,7 +985,18 @@ var SummaryWidget = /*#__PURE__*/function (_React$Component) {
               return {
                 rtData: _objectSpread(_objectSpread({}, prevState.rtData), {}, summaryWidget_defineProperty({}, key, _objectSpread(_objectSpread({}, prevState.rtData[key]), {}, summaryWidget_defineProperty({}, sub_key, _this2.props.x.rtData[key][sub_key]))))
               };
-            });
+            }); // Handle max date here
+
+
+            if (['rtData', 'casesInfectionData', 'casesReportData'].includes(sub_key)) {
+              var min_date = summaryWidget_d3.min(_this2.get_dates(_this2.filterData(_this2.state.active_area, _this2.props.x.rtData[key][sub_key])));
+              var max_date = summaryWidget_d3.max(_this2.get_dates(_this2.filterData(_this2.state.active_area, _this2.props.x.rtData[key][sub_key])));
+
+              _this2.setState({
+                min_date: min_date,
+                max_date: max_date
+              });
+            }
           }
         });
       });
@@ -1065,6 +1076,8 @@ var SummaryWidget = /*#__PURE__*/function (_React$Component) {
   }, {
     key: "render",
     value: function render() {
+      console.log(this.state);
+
       if (Object.keys(this.state.rtData[this.state.active_source]).length <= 3) {
         return /*#__PURE__*/summaryWidget_React.createElement("div", {
           className: "d-flex justify-content-center pt-4"

--- a/src/CountrySelect.js
+++ b/src/CountrySelect.js
@@ -11,7 +11,7 @@ export default class CountrySelect extends React.Component{
 
     var region_options = []
     this.props.summaryData.map(item => {
-      region_options.push(<option>{item['Country']}</option>)
+      region_options.push(<option>{item[this.props.data_ref['summaryData']['geometry_name']]}</option>)
     })
 
     var source_options = []

--- a/src/Map.js
+++ b/src/Map.js
@@ -81,10 +81,12 @@ export default class Map extends React.Component{
               return('<b>' + hovered_data[summaryData_geometry_name] + '</b></br><b>' + legend_ref['variable_name'] + ': </b>' + hovered_data[legend_ref['variable_name']])
             }
 
+            console.log(e)
+
             try {
               d3.select('#' + container_id + '-tooltip')
-                .style("left", (e.clientX + 40) + "px")
-                .style("top", (e.clientY) + "px")
+                .style("left", (e.pageX + 40) + "px")
+                .style("top", (e.pageY) + "px")
                 .html(format_tooltip_string(hovered_data, legend_ref))
             } catch {
               d3.select('#' + container_id + '-tooltip')

--- a/src/Map.js
+++ b/src/Map.js
@@ -61,11 +61,11 @@ export default class Map extends React.Component{
             var hovered_name = d3.select(this).attr('region-name')
 
             var hovered_data = data.filter(d => {
-              return( d.Country == hovered_name)
+              return( d.region == hovered_name)
             })[0]
 
             function format_tooltip_string(hovered_data, legend_ref){
-              return('<b>' + hovered_data['Country'] + '</b></br><b>' + legend_ref['variable_name'] + ': </b>' + hovered_data[legend_ref['variable_name']])
+              return('<b>' + hovered_data['region'] + '</b></br><b>' + legend_ref['variable_name'] + ': </b>' + hovered_data[legend_ref['variable_name']])
             }
 
             try {
@@ -115,7 +115,7 @@ export default class Map extends React.Component{
   sequential_fill(feature_name, summaryData, legend_scale, legend_ref){
 
     var summary_data = summaryData.filter(function(d){
-      if (d.Country == feature_name){
+      if (d.region == feature_name){
         return(
           d
         )
@@ -139,7 +139,7 @@ export default class Map extends React.Component{
   qualitative_fill(feature_name, summaryData, legend_ref){
 
     var summary_data = summaryData.filter(function(d){
-      if (d.Country == feature_name){
+      if (d.region == feature_name){
         return(
           d
         )

--- a/src/Map.js
+++ b/src/Map.js
@@ -15,6 +15,8 @@ export default class Map extends React.Component{
 
     var svg_dims = document.getElementById(this.props.container_id).getBoundingClientRect()
 
+    var summaryData_geometry_name = this.props.data_ref['summaryData']['geometry_name']
+
     const projection = d3[this.props.projection]()
       .fitSize([svg_dims.width, svg_dims.height], this.props.geoData);
 
@@ -43,16 +45,27 @@ export default class Map extends React.Component{
         .enter().append("path")
           .attr("d", path)
           .attr('region-name', (feature => {
-            return(feature.properties.sovereignt)
+            return(feature.properties[this.props.data_ref['geoData']['geometry_name']])
           }))
       		.attr('fill', (feature => {
 
-            var feature_name = feature.properties.sovereignt
+            var feature_name = feature.properties[this.props.data_ref['geoData']['geometry_name']]
 
             if (this.props.legend_ref['legend_type'] === 'qualitative'){
-              return(this.qualitative_fill(feature_name, this.props.summaryData, this.props.legend_ref))
+
+              return(this.qualitative_fill(feature_name,
+                this.props.summaryData,
+                summaryData_geometry_name,
+                this.props.legend_ref))
+
             } else if (this.props.legend_ref['legend_type'] === 'sequential'){
-              return(this.sequential_fill(feature_name, this.props.summaryData, scale_sequential, this.props.legend_ref))
+
+              return(this.sequential_fill(feature_name,
+                this.props.summaryData,
+                summaryData_geometry_name,
+                scale_sequential,
+                this.props.legend_ref))
+
             }
 
           }))
@@ -61,11 +74,11 @@ export default class Map extends React.Component{
             var hovered_name = d3.select(this).attr('region-name')
 
             var hovered_data = data.filter(d => {
-              return( d.region == hovered_name)
+              return( d[summaryData_geometry_name] == hovered_name)
             })[0]
 
             function format_tooltip_string(hovered_data, legend_ref){
-              return('<b>' + hovered_data['region'] + '</b></br><b>' + legend_ref['variable_name'] + ': </b>' + hovered_data[legend_ref['variable_name']])
+              return('<b>' + hovered_data[summaryData_geometry_name] + '</b></br><b>' + legend_ref['variable_name'] + ': </b>' + hovered_data[legend_ref['variable_name']])
             }
 
             try {
@@ -112,10 +125,10 @@ export default class Map extends React.Component{
     svg.call(zoom);
 
   }
-  sequential_fill(feature_name, summaryData, legend_scale, legend_ref){
+  sequential_fill(feature_name, summaryData, geometry_name, legend_scale, legend_ref){
 
     var summary_data = summaryData.filter(function(d){
-      if (d.region == feature_name){
+      if (d[geometry_name] == feature_name){
         return(
           d
         )
@@ -136,10 +149,10 @@ export default class Map extends React.Component{
 
 
   }
-  qualitative_fill(feature_name, summaryData, legend_ref){
+  qualitative_fill(feature_name, summaryData, geometry_name, legend_ref){
 
     var summary_data = summaryData.filter(function(d){
-      if (d.region == feature_name){
+      if (d[geometry_name] == feature_name){
         return(
           d
         )

--- a/src/Map.js
+++ b/src/Map.js
@@ -81,8 +81,6 @@ export default class Map extends React.Component{
               return('<b>' + hovered_data[summaryData_geometry_name] + '</b></br><b>' + legend_ref['variable_name'] + ': </b>' + hovered_data[legend_ref['variable_name']])
             }
 
-            console.log(e)
-
             try {
               d3.select('#' + container_id + '-tooltip')
                 .style("left", (e.pageX + 40) + "px")

--- a/src/TimeseriesPlot.js
+++ b/src/TimeseriesPlot.js
@@ -18,6 +18,7 @@ export default class TimeseriesPlot extends React.Component{
       this.createTsPlot()
    }
   getCIs(data){
+
     var ci = Object.keys(data[0]).map(key => {return this.parseCI(key)})
 
     var ci = ci.filter(function(x) {return x !== undefined;});
@@ -87,7 +88,9 @@ export default class TimeseriesPlot extends React.Component{
     var cis = this.getCIs(this.props.data)
 
     // Get the value of the highest CI
-    var max_ci = d3.max(cis.map(ci => {return(ci['value'])}))
+    var cis_numeric = cis.map(ci => {return(ci['value'])})
+
+    var max_ci = d3.max(cis_numeric)
 
     // Y max is the max of the highest CI
     var y_max = d3.max(this.props.data.map(d => parseFloat(d['upper_' + max_ci])))

--- a/src/TimeseriesPlot.js
+++ b/src/TimeseriesPlot.js
@@ -211,7 +211,8 @@ export default class TimeseriesPlot extends React.Component{
       .attr('transform', 'translate(' + this.margin.left + ',' + this.margin.top + ')')
       .call(zoom)
       .on('mousemove', (e => {
-        var hovered_x = this.active_x.invert(e.clientX)
+
+        var hovered_x = this.active_x.invert(e.pageX)
 
         var hovered_x_formatted = hovered_x.toISOString().slice(0,10)
 
@@ -224,13 +225,13 @@ export default class TimeseriesPlot extends React.Component{
         var tooltip_string = this.format_tooltip_string(hover_data, cis, this.props.data_ref['rtData']['geometry_name'])
 
         d3.select('#' + this.props.container_id + '-tooltip')
-          .style("left", (e.clientX + 40) + "px")
-          .style("top", (e.clientY + this.props.map_height - 200) + "px")
+          .style("left", (e.pageX + 40) + "px")
+          .style("top", (e.pageY) + "px")
           .html(tooltip_string)
 
         d3.select('#' + this.props.container_id + '-hover-line')
-          .attr('x1', e.clientX - 60)
-          .attr('x2', e.clientX - 60)
+          .attr('x1', e.pageX - 60)
+          .attr('x2', e.pageX - 60)
 
       }))
       .on('mouseenter', (e => {

--- a/src/TimeseriesPlot.js
+++ b/src/TimeseriesPlot.js
@@ -221,7 +221,7 @@ export default class TimeseriesPlot extends React.Component{
           }
         })[0];
 
-        var tooltip_string = this.format_tooltip_string(hover_data, cis)
+        var tooltip_string = this.format_tooltip_string(hover_data, cis, this.props.data_ref['rtData']['geometry_name'])
 
         d3.select('#' + this.props.container_id + '-tooltip')
           .style("left", (e.clientX + 40) + "px")
@@ -306,11 +306,11 @@ export default class TimeseriesPlot extends React.Component{
     }
 
   };
-  format_tooltip_string(hover_data, cis){
+  format_tooltip_string(hover_data, cis, geometry_name){
 
     var sep = '</br>'
 
-    var hover_str = '<b>' + hover_data['country'] + '</b>' + sep + '<b>' + hover_data['date'] + '</b>'
+    var hover_str = '<b>' + hover_data[geometry_name] + '</b>' + sep + '<b>' + hover_data['date'] + '</b>'
 
     hover_str = hover_str + cis.map(ci => {
       return(sep + '<b>' +ci['value'] + '% CI: </b>' + hover_data[ci['lower_name']] + ' - ' + hover_data[ci['upper_name']])

--- a/src/summaryWidget.js
+++ b/src/summaryWidget.js
@@ -232,7 +232,8 @@ export default class SummaryWidget extends React.Component{
                        data_sources={Object.keys(this.state.rtData)}
                        active_area={this.state.active_area}
                        select_handler={this.update_region_state.bind(this)}
-                       source_select_handler={this.update_source_state.bind(this)}>
+                       source_select_handler={this.update_source_state.bind(this)}
+                       data_ref={this.props.x.data_ref}>
         </CountrySelect>
         <TimeseriesPlot container_id='r-container'
                         svg_id='r-svg'

--- a/src/summaryWidget.js
+++ b/src/summaryWidget.js
@@ -89,6 +89,14 @@ export default class SummaryWidget extends React.Component{
         }))
 
         // Handle max date here
+        if (['rtData', 'casesInfectionData', 'casesReportData'].includes(sub_key)){
+
+          var min_date = d3.min(this.get_dates(this.filterData(this.state.active_area, this.props.x.rtData[key][sub_key])))
+          var max_date = d3.max(this.get_dates(this.filterData(this.state.active_area, this.props.x.rtData[key][sub_key])))
+
+          this.setState({min_date: min_date, max_date: max_date})
+
+        }
 
       }
 
@@ -171,6 +179,8 @@ export default class SummaryWidget extends React.Component{
   }
 
   render() {
+
+    console.log(this.state)
 
     if (Object.keys(this.state.rtData[this.state.active_source]).length <= 3) {
 

--- a/src/summaryWidget.js
+++ b/src/summaryWidget.js
@@ -180,8 +180,6 @@ export default class SummaryWidget extends React.Component{
 
   render() {
 
-    console.log(this.state)
-
     if (Object.keys(this.state.rtData[this.state.active_source]).length <= 3) {
 
       return(
@@ -196,7 +194,8 @@ export default class SummaryWidget extends React.Component{
       var activeCasesReportData = this.filterData(this.state.active_area, this.state.rtData[this.state.active_source]['casesReportData'])
       var activeObsCasesData = this.filterData(this.state.active_area, this.state.rtData[this.state.active_source]['obsCasesData'])
 
-
+      console.log(this.state.rtData[this.state.active_source]['summaryData'])
+      console.log(this.props.x)
 
       const plot_height = '200px'
       const map_height = 600

--- a/src/summaryWidget.js
+++ b/src/summaryWidget.js
@@ -28,9 +28,13 @@ export default class SummaryWidget extends React.Component{
     // Default to the first map legend
     this.setState({active_map_legend: this.props.x.map_legend_ref[0]})
 
-    this.props.x.geoData.then(data => {
-      this.setState({geoData: data})
-    })
+    try {
+      this.props.x.geoData.then(data => {
+        this.setState({geoData: data})
+      })
+    } catch {
+      this.setState({geoData: this.props.x.geoData})
+    }
 
     //rtData is nested recursively
     Object.keys(this.props.x.rtData).map((key, index) => {
@@ -143,6 +147,7 @@ export default class SummaryWidget extends React.Component{
 
     return(legend_scale)
   }
+
   render() {
 
     if (Object.keys(this.state.rtData[this.state.active_source]).length <= 3) {

--- a/src/summaryWidget.js
+++ b/src/summaryWidget.js
@@ -66,8 +66,15 @@ export default class SummaryWidget extends React.Component{
             // Also setting the min and max dates of the active area here
             if (['rtData', 'casesInfectionData', 'casesReportData'].includes(sub_key)){
 
-              var min_date = d3.min(this.get_dates(this.filterData(this.state.active_area, data)))
-              var max_date = d3.max(this.get_dates(this.filterData(this.state.active_area, data)))
+              var min_date = d3.min(this.get_dates(this.filterData(this.state.active_area,
+                data,
+                this.props.x.data_ref[sub_key]['geometry_name']
+              )))
+
+              var max_date = d3.max(this.get_dates(this.filterData(this.state.active_area,
+                data,
+                this.props.x.data_ref[sub_key]['geometry_name']
+              )))
 
               this.setState({min_date: min_date, max_date: max_date})
 
@@ -138,24 +145,11 @@ export default class SummaryWidget extends React.Component{
     return dates
 
   }
-  filterData(region, input, filter_var='region'){
+  filterData(region, input, geometry_name, filter_var='region'){
     // Filters an array for an arbitrary value by an arbitrary column
 
-    var input_keys = Object.keys(input[0])
-
-    // Add flexibility for the most common filtered variables. Assumes there is only one of these per dataset
-    if (input_keys.includes('region')){
-      filter_var = 'region'
-    } else if (input_keys.includes('country')){
-      filter_var = 'country'
-    } else if (input_keys.includes('Country')){
-      filter_var = 'Country'
-    } else if (input_keys.includes('Region')){
-      filter_var = 'Region'
-    }
-
     var filtered = input.filter(function (e) {
-        return e[filter_var] == region;
+        return e[geometry_name] == region;
     });
 
     return ( filtered )
@@ -189,13 +183,23 @@ export default class SummaryWidget extends React.Component{
       )
 
     } else {
-      var activeRtData = this.filterData(this.state.active_area, this.state.rtData[this.state.active_source]['rtData'])
-      var activeCasesInfectionData = this.filterData(this.state.active_area, this.state.rtData[this.state.active_source]['casesInfectionData'])
-      var activeCasesReportData = this.filterData(this.state.active_area, this.state.rtData[this.state.active_source]['casesReportData'])
-      var activeObsCasesData = this.filterData(this.state.active_area, this.state.rtData[this.state.active_source]['obsCasesData'])
 
-      console.log(this.state.rtData[this.state.active_source]['summaryData'])
-      console.log(this.props.x)
+      var activeRtData = this.filterData(this.state.active_area,
+        this.state.rtData[this.state.active_source]['rtData'],
+        this.props.x.data_ref['rtData']['geometry_name']
+      )
+      var activeCasesInfectionData = this.filterData(this.state.active_area,
+        this.state.rtData[this.state.active_source]['casesInfectionData'],
+        this.props.x.data_ref['casesInfectionData']['geometry_name']
+      )
+      var activeCasesReportData = this.filterData(this.state.active_area,
+        this.state.rtData[this.state.active_source]['casesReportData'],
+        this.props.x.data_ref['casesReportData']['geometry_name']
+      )
+      var activeObsCasesData = this.filterData(this.state.active_area,
+        this.state.rtData[this.state.active_source]['obsCasesData'],
+        this.props.x.data_ref['obsCasesData']['geometry_name']
+      )
 
       const plot_height = '200px'
       const map_height = 600
@@ -209,6 +213,7 @@ export default class SummaryWidget extends React.Component{
              height= {map_height + 'px'}
              geoData={this.state.geoData}
              summaryData={this.state.rtData[this.state.active_source]['summaryData']}
+             data_ref={this.props.x.data_ref}
              projection={this.props.x.projection}
              legend_ref={this.state.active_map_legend}
              create_sequential_legend={this.create_sequential_legend}
@@ -239,6 +244,7 @@ export default class SummaryWidget extends React.Component{
                         min_date={this.state.min_date}
                         max_date={this.state.max_date}
                         ts_color_ref={this.props.x.ts_color_ref}
+                        data_ref={this.props.x.data_ref}
                         data={activeRtData}
                         map_height={map_height}
                         hline_intercept={1}>
@@ -253,6 +259,7 @@ export default class SummaryWidget extends React.Component{
                         min_date={this.state.min_date}
                         max_date={this.state.max_date}
                         ts_color_ref={this.props.x.ts_color_ref}
+                        data_ref={this.props.x.data_ref}
                         data={activeCasesInfectionData}
                         map_height={map_height}
                         obsCasesData={activeObsCasesData}
@@ -269,6 +276,7 @@ export default class SummaryWidget extends React.Component{
                         min_date={this.state.min_date}
                         max_date={this.state.max_date}
                         ts_color_ref={this.props.x.ts_color_ref}
+                        data_ref={this.props.x.data_ref}
                         data={activeCasesReportData}
                         map_height={map_height}
                         obsCasesData={activeObsCasesData}

--- a/src/summaryWidget.js
+++ b/src/summaryWidget.js
@@ -28,6 +28,7 @@ export default class SummaryWidget extends React.Component{
     // Default to the first map legend
     this.setState({active_map_legend: this.props.x.map_legend_ref[0]})
 
+    // Try to resolve promise or accept array
     try {
       this.props.x.geoData.then(data => {
         this.setState({geoData: data})
@@ -36,6 +37,11 @@ export default class SummaryWidget extends React.Component{
       this.setState({geoData: this.props.x.geoData})
     }
 
+    try {
+
+    } catch {
+
+    }
     //rtData is nested recursively
     Object.keys(this.props.x.rtData).map((key, index) => {
 
@@ -43,32 +49,48 @@ export default class SummaryWidget extends React.Component{
 
       Object.keys(this.props.x.rtData[key]).map((sub_key, sub_index) => {
 
-        this.props.x.rtData[key][sub_key].then(data => {
+        try {
+          this.props.x.rtData[key][sub_key].then(data => {
 
-          // setState needs to be called for nested state
-          this.setState(prevState => ({
-              rtData: {
-                  ...prevState.rtData,
-                  [key]: {
-                      ...prevState.rtData[key],
-                      [sub_key]: data
-                  }
-              }
-          }))
+            // setState needs to be called for nested state
+            this.setState(prevState => ({
+                rtData: {
+                    ...prevState.rtData,
+                    [key]: {
+                        ...prevState.rtData[key],
+                        [sub_key]: data
+                    }
+                }
+            }))
 
-          // Also setting the min and max dates of the active area here
-          if (['rtData', 'casesInfectionData', 'casesReportData'].includes(sub_key)){
+            // Also setting the min and max dates of the active area here
+            if (['rtData', 'casesInfectionData', 'casesReportData'].includes(sub_key)){
 
-            var min_date = d3.min(this.get_dates(this.filterData(this.state.active_area, data)))
-            var max_date = d3.max(this.get_dates(this.filterData(this.state.active_area, data)))
+              var min_date = d3.min(this.get_dates(this.filterData(this.state.active_area, data)))
+              var max_date = d3.max(this.get_dates(this.filterData(this.state.active_area, data)))
 
-            this.setState({min_date: min_date, max_date: max_date})
+              this.setState({min_date: min_date, max_date: max_date})
 
-          }
+            }
 
-          }
+            }
 
-        )
+          )
+      } catch {
+
+        this.setState(prevState => ({
+            rtData: {
+                ...prevState.rtData,
+                [key]: {
+                    ...prevState.rtData[key],
+                    [sub_key]: this.props.x.rtData[key][sub_key]
+                }
+            }
+        }))
+
+        // Handle max date here
+
+      }
 
       })
     })


### PR DESCRIPTION
Resolves issues with different column names in input data and tooltip positioning relative to page not client. 

Adds `data_ref` prop which specifies the `geometry_name` property for each dataset type, used to identify which column hold the geometry that should be symbolised. 

Timeseries tooltips will fail if `geometry_name` in `rtData`, `casesInfectionData`, `casesReportData` are different. This is a small error and unlikely in practice so I'm not going to address it for now.